### PR TITLE
Added a license, intended for discussion before merging.

### DIFF
--- a/CC-LICENSE-BY-3.0.txt
+++ b/CC-LICENSE-BY-3.0.txt
@@ -1,0 +1,9 @@
+This work is licensed under the 
+Creative Commons Attribution 3.0 Unported License. 
+To view a copy of this license, visit 
+http://creativecommons.org/licenses/by/3.0/.
+
+To make an attribution to this work, please mention either of
+the following URLs:
+http://bio2rdf.org
+https://github.com/bio2rdf/bio2rdf-mapping


### PR DESCRIPTION
It was not clear in the mailing list discussion what the intended license for these ontologies is. I chose CC-BY-3.0 fairly arbitrarily. MIT license is intended for software, and ontologies are not software as such. CC-BY-3.0 is more restrictive though than MIT, and maybe we should go with CC-0, public domain.
